### PR TITLE
Update vendor path in API documentation

### DIFF
--- a/_includes/index.md
+++ b/_includes/index.md
@@ -150,7 +150,7 @@ of the Google Closure Compiler ( it's JavaScript only ).
 Where the bundles will be copied within your destination
 folder.
 
-Default: `/bundles/`.
+Default: `/vendor/bundles/`.
 
 ### server_url:
 


### PR DESCRIPTION
This updates the API docs to reference the default path for bundles in the current release. :tada::balloon:
